### PR TITLE
Reduce colours on homepage

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.34",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -572,7 +572,8 @@ button.back::after {
 	--midland-red: #DC143C;
 	--south-eastern-yellow: #FECB09;
 	--great-western-green: #013602;
-	--great-northern-green: #00A550;
+	/* Slighty darkened, original was #00A550 */
+	--great-northern-green: rgb(0, 156, 76);
 	--north-western-blue: #080028;
 	--great-northern-blue: #0099FF;
 	--alt-blue: #0284db;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -907,7 +907,17 @@ a {
 	gap: 1.8em;
 }
 
-.social-container .instagram {
+.social-container a {
+	background: none;
+	color: #fff;
+	border: solid 2px #fff;
+}
+
+.social-container a:hover {
+	filter: brightness(60%);
+}
+
+/*.social-container .instagram {
 	background-color: #F00075;
 }
 
@@ -923,7 +933,7 @@ a {
 .social-container .twitter:hover {
 	background-color: #187abb;
 	color: #fff;
-}
+}*/
 
 .social-container a {
 	border-radius: 100px;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -914,9 +914,11 @@ a {
 }
 
 .social-container a:hover {
-	filter: brightness(60%);
+	background-color: rgba(255, 255, 255, 0.12);
+	color: #fff !important;
 }
 
+/* Old, colours social icons */
 /*.social-container .instagram {
 	background-color: #F00075;
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -373,7 +373,7 @@ button.back::after {
 }
 
 .r-banner-alert-INFO {
-	background-color: var(--great-northern-blue);
+	background-color: var(--french-blue-brighter);
 }
 
 .r-banner-alert-INFO h3 {
@@ -575,7 +575,7 @@ button.back::after {
 	/* Slighty darkened, original was #00A550 */
 	--great-northern-green: rgb(0, 156, 76);
 	--north-western-blue: #080028;
-	--great-northern-blue: #0099FF;
+	--french-blue-brighter: #2B69D4;
 	--alt-blue: #0284db;
 
 	--an-orange: #F4511E;
@@ -730,7 +730,7 @@ a {
 }
 
 .sosumi .input-container:focus-within::after {
-	background-color: var(--great-northern-blue);
+	background-color: var(--french-blue-brighter);
 }
 
 /* checkbox wrapper */
@@ -976,7 +976,7 @@ a {
 }
 
 .footer a:hover {
-	color: var(--great-northern-blue);
+	color: var(--french-blue-brighter);
 }
 
 .footer #feedback-buttom {

--- a/frontend/src/components/EventsList.tsx
+++ b/frontend/src/components/EventsList.tsx
@@ -3,12 +3,27 @@ import { scrollUp, scrollDown } from "../utils/scroll";
 import EventRow from "./EventRow";
 
 /**
+ * Here's how it works:
+ * - Current we just deploy a static JSON file with events and alerts in.
+ * - These (and by extension the API) are currently described in terms of TS interfaces below.
+ * 
+ * Essentially there's a base event type, which has an eventType field
+ * which TS then uses to infer the extra props for different event types (fundraiser, charity event and house event)
+ * that are shown as the interfaces below)
+ * 
+ * @packageDocumentation
+ */
+
+/**
  * Used to distinguish between the different type of event we can display.
  */
 export enum EventTypes {
-	HOUSE = "house", // house event
-	CHARITY = "charity", // charity event
-	FUNDRIASER = "fundraiser" // cahrity fundraiser
+	/** house event */
+	HOUSE = "house",
+	/** charity event */
+	CHARITY = "charity", 
+	/** charity fundraiser */
+	FUNDRIASER = "fundraiser"
 } 
 
 export enum KECHBHouses {
@@ -18,6 +33,7 @@ export enum KECHBHouses {
 	Tudor = "Tudor"
 }
 
+/** Base event intergace - all events need to have these properties */
 export interface BaseEventItem {
 	title: string;
 	description?: string;
@@ -38,12 +54,20 @@ export interface BaseEventItem {
 	when?: string,
 }
 
+/**
+ * Props specific to fundraisers.
+ * For {@link EventTypes.FUNDRIASER}
+*/
 export interface EventItemFundraiser extends BaseEventItem {
 	eventType: EventTypes.FUNDRIASER | "fundraiser";
 	url: string;
 	target: string;
 }
 
+/**
+ * Props specific to charity events.
+ * For {@link EventTypes.CHARITY}
+*/
 export interface EventItemCharity extends BaseEventItem {
 	eventType: EventTypes.CHARITY | "charity";
 	url: string;
@@ -54,6 +78,10 @@ export interface EventItemCharity extends BaseEventItem {
 	};
 }
 
+/**
+ * Props specific to house events.
+ * For {@link EventTypes.HOUSE}
+*/
 export interface EventItemHouse extends BaseEventItem {
 	eventType: EventTypes.HOUSE | "house";
 	/** String time of event. Either a term (e.g. "Autumn"), date */
@@ -75,8 +103,16 @@ export interface EventItemHouse extends BaseEventItem {
 	backgroundColor: string;
 }*/
 
+/**
+ * IMPORTANT: Merges the event types into one type.
+ * 
+ * TS type inference then auto-picks the right type based on `eventType` field.
+ */
 export type EventItem = EventItemFundraiser | EventItemCharity | EventItemHouse;
 
+/**
+ * Expected API response
+ */
 export interface EventData {
 	events: Array<EventItem>;
 	generatedAt: string; // Timestamp

--- a/frontend/src/components/SiteContainer.tsx
+++ b/frontend/src/components/SiteContainer.tsx
@@ -46,7 +46,15 @@ interface TheState {
 
 /**
  * Contains the site of isitweeka.com itself.
- * They way, we can easily create variations of it for e.g. different school
+ * They way, we can easily create variations of it for e.g. different school.
+ * 
+ * How calendar loading works:
+ * 1. We have a GitHub Action that every Friday fetches KECHB and KECHG school calendar and uploads it to the repo for deployment.
+ * 2. The site fetches this:
+ * 	1. goes back to the last `weekMarkerDate` (e.g. Monday - {@link SiteProps.weekMarkerDate}),
+ * 		based on the current UTC date.
+ * 		It goes forward to the next `weekMarkerDate` if it is a weekend.
+ * 	2. Sees if a Week A or Week B event is in the calendar on the day. If not, displays a messages saying it's likely a holiday.
  */
 export default class SiteContainer extends Component<SiteProps, TheState> {
 
@@ -154,6 +162,7 @@ export default class SiteContainer extends Component<SiteProps, TheState> {
 
 	/**
 	 * Loads the KECHB calendar, finds the current week, then goes to the Monday of that week and checks for a Week A or Week B event.
+	 * @see SiteContainer documentation for more information on the algoirthm
 	 */
 	async getCalendar() {
 		const inputDate = new Date();
@@ -161,6 +170,8 @@ export default class SiteContainer extends Component<SiteProps, TheState> {
 		// inputDate.setDate(1);
 		// inputDate.setMonth(0);
 		// inputDate.setFullYear(2021);
+
+		// THis is where we get the date in the calendar to look for (i.e. go back to the last or next Monday)
 		const weekStart = this.forwardOrRewindToDay(inputDate, this.props.weekMarkerDate, [0, 6]);
 		weekStart.setUTCHours(0, 0, 0, 0); // Set to start of day
 		const weekEnd = new Date(weekStart);
@@ -178,6 +189,7 @@ export default class SiteContainer extends Component<SiteProps, TheState> {
 		const startTime = weekStart.toISOString();
 		const endTime = weekEnd.toISOString();
 
+		// Fetch the iCal fikle
 		const baseResponse = await fetch(this.props.calendarURL, {
 			method: "GET",
 			mode: "no-cors",


### PR DESCRIPTION
Following feedback (see #38) we've created this PR to reduce the number of colours on the site.

Changes:
1. Make social icons more minimal, with no coloured background and an outline instead
2. Adjust INFO green to be darker, and use a different blue for INFO.  Blue checked against WebAIM standards.